### PR TITLE
feat: 카드 등록 화면 디자인 설정

### DIFF
--- a/src/assets/img/back-icon.svg
+++ b/src/assets/img/back-icon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 7L9 12L14 17" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -6,6 +6,7 @@ import * as styles from '@/styles/Register.css';
 import { CardForm, card } from '@/api/card';
 import PasswordInput from './PasswordInput';
 import { useNavigate } from 'react-router-dom';
+import BackIcon from '@/assets/img/back-icon.svg?react';
 
 const Register = () => {
   const navigate = useNavigate();
@@ -64,6 +65,13 @@ const Register = () => {
 
   return (
     <div>
+      <header className={styles.header}>
+        <button className={styles.backButton} onClick={() => navigate('/')}>
+          <BackIcon />
+        </button>
+        <div className={styles.headerName}>카드 등록하기</div>
+        <div></div>
+      </header>
       {!showPasswordInput ? (
         <form onSubmit={handleSubmit} className={styles.form}>
           <label className={styles.label}>

--- a/src/styles/Register.css.ts
+++ b/src/styles/Register.css.ts
@@ -1,5 +1,27 @@
 import { style } from '@vanilla-extract/css';
 
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '16px 20px',
+  height: '48px',
+  backgroundColor: '#ffffff',
+  borderBottom: '1px solid #e5e7eb',
+  position: 'sticky',
+  top: 0,
+  zIndex: 10,
+});
+
+export const backButton = style({
+  backgroundColor: 'transparent',
+  borderColor: 'transparent',
+});
+
+export const headerName = style({
+  fontWeight: 'bold',
+});
+
 export const form = style({
   display: 'flex',
   flexDirection: 'column',


### PR DESCRIPTION
카드등록 화면에 Header를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 카드 등록 페이지 상단에 뒤로가기 버튼과 "카드 등록하기" 제목이 포함된 헤더가 추가되었습니다.

- **스타일**
  - 카드 등록 페이지의 헤더, 뒤로가기 버튼, 제목에 대한 새로운 스타일이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->