### PR TITLE
feat: 카드 등록 약관 동의 페이지 추가

### DIFF
--- a/src/components/Main/CardActions/index.tsx
+++ b/src/components/Main/CardActions/index.tsx
@@ -1,17 +1,14 @@
 import * as styles from '@/styles/Main.css';
 import { useNavigate } from 'react-router-dom';
-import AddIcon from '@/assets/img/add-icon.svg?react'
-import OptionIcon from '@/assets/img/option-icon.svg?react'
+import AddIcon from '@/assets/img/add-icon.svg?react';
+import OptionIcon from '@/assets/img/option-icon.svg?react';
 
 const CardActions = () => {
   const navigate = useNavigate();
 
   return (
     <div className={styles.cardActionWrapper}>
-      <button
-        className={styles.cardAddButton}
-        onClick={() => navigate('/register')}
-      >
+      <button className={styles.cardAddButton} onClick={() => navigate('/register/agreement')}>
         <AddIcon />
         <span>카드 추가하기</span>
       </button>
@@ -21,7 +18,6 @@ const CardActions = () => {
         <span>카드 관리하기</span>
       </button>
     </div>
-
   );
 };
 

--- a/src/pages/Register/RegisterAgreement/index.tsx
+++ b/src/pages/Register/RegisterAgreement/index.tsx
@@ -1,0 +1,135 @@
+import BackIcon from '@/assets/img/back-icon.svg?react';
+import * as styles from '@/styles/Register.css';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const RegisterAgreement = () => {
+  const navigate = useNavigate();
+
+  const [check1, setCheck1] = useState(false);
+  const [check2, setCheck2] = useState(false);
+  const [check3, setCheck3] = useState(false);
+  const [check4, setCheck4] = useState(false);
+  const [check5, setCheck5] = useState(false);
+
+  return (
+    <div>
+      <header className={styles.header}>
+        <button className={styles.backButton} onClick={() => navigate('/')}>
+          <BackIcon />
+        </button>
+        <div className={styles.headerName}>카드 등록하기</div>
+        <div></div>
+      </header>
+
+      <div>
+        <h1 className={styles.agreementTitle}>
+          {'안전한 결제를 위해 카드 연결 약관에'}
+          <br />
+          {'동의해주세요.'}
+        </h1>
+
+        <div className={styles.agreementDescription}>
+          {'카드를 등록하면 원활한 거래 진행을 위해'}
+          <br />
+          {'안전하게 사용할 수 있습니다.'}
+        </div>
+      </div>
+
+      <div>
+        <div className={styles.agreementItem}>
+          <div className={styles.agreementItemOption}>(필수)</div>
+          <div className={styles.agreementItemTitle}>오픈뱅킹 출금 이체 동의</div>
+          <button
+            className={!check1 ? styles.agreementItemUnCheck : styles.agreementItemCheck}
+            onClick={() => {
+              setCheck1(!check1);
+            }}
+          >
+            ✓
+          </button>
+        </div>
+        <div className={styles.agreementItem}>
+          <div className={styles.agreementItemOption}>(필수)</div>
+          <div className={styles.agreementItemTitle}>전자금융거래 이용 약관 동의</div>
+          <button
+            className={!check2 ? styles.agreementItemUnCheck : styles.agreementItemCheck}
+            onClick={() => {
+              setCheck2(!check2);
+            }}
+          >
+            ✓
+          </button>
+        </div>
+        <div className={styles.agreementItem}>
+          <div className={styles.agreementItemOption}>(필수)</div>
+          <div className={styles.agreementItemTitle}>개인정보 제3자 제공 동의</div>
+          <button
+            className={!check3 ? styles.agreementItemUnCheck : styles.agreementItemCheck}
+            onClick={() => {
+              setCheck3(!check3);
+            }}
+          >
+            ✓
+          </button>
+        </div>
+        <div className={styles.agreementItem}>
+          <div className={styles.agreementItemOption}>(필수)</div>
+          <div className={styles.agreementItemTitle}>은행 출금이체 약관</div>
+          <button
+            className={!check4 ? styles.agreementItemUnCheck : styles.agreementItemCheck}
+            onClick={() => {
+              setCheck4(!check4);
+            }}
+          >
+            ✓
+          </button>
+        </div>
+        <div className={styles.agreementItem}>
+          <div className={styles.agreementItemOption}>(필수)</div>
+          <div className={styles.agreementItemTitle}>본인 확인 및 인증 동의</div>
+          <button
+            className={!check5 ? styles.agreementItemUnCheck : styles.agreementItemCheck}
+            onClick={() => {
+              setCheck5(!check5);
+            }}
+          >
+            ✓
+          </button>
+        </div>
+      </div>
+
+      <button
+        className={styles.button}
+        onClick={() => {
+          if (!check1) {
+            alert('오픈뱅킹 출금 이체에 동의해주세요.');
+            return;
+          }
+          if (!check2) {
+            alert('전자금융거래 이용 약관에 동의해주세요.');
+            return;
+          }
+          if (!check3) {
+            alert('개인정보 제3자 제공에 동의해주세요.');
+            return;
+          }
+          if (!check4) {
+            alert('은행 출금 이체에 동의해주세요.');
+            return;
+          }
+          if (!check5) {
+            alert('본인 확인 및 인증에 동의해주세요.');
+            return;
+          }
+
+          navigate('/register');
+        }}
+      >
+        다음
+      </button>
+    </div>
+  );
+};
+
+export default RegisterAgreement;

--- a/src/pages/Register/RegisterAgreement/index.tsx
+++ b/src/pages/Register/RegisterAgreement/index.tsx
@@ -3,14 +3,70 @@ import * as styles from '@/styles/Register.css';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+const AgreementItem = ({
+  label,
+  isChecked,
+  onToggle,
+}: {
+  label: string;
+  isChecked: boolean;
+  onToggle: () => void;
+}) => (
+  <div className={styles.agreementItem}>
+    <div className={styles.agreementItemOption}>(필수)</div>
+    <div className={styles.agreementItemTitle}>{label}</div>
+    <button
+      className={!isChecked ? styles.agreementItemUnCheck : styles.agreementItemCheck}
+      onClick={onToggle}
+    >
+      ✓
+    </button>
+  </div>
+);
+
 const RegisterAgreement = () => {
   const navigate = useNavigate();
 
-  const [check1, setCheck1] = useState(false);
-  const [check2, setCheck2] = useState(false);
-  const [check3, setCheck3] = useState(false);
-  const [check4, setCheck4] = useState(false);
-  const [check5, setCheck5] = useState(false);
+  const [agreements, setAgreements] = useState({
+    openBanking: false,
+    electronFinance: false,
+    personalInfo: false,
+    bankTransfer: false,
+    identification: false,
+  });
+
+  const updateAgreement = (key: keyof typeof agreements) => {
+    setAgreements((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const agreementItems = [
+    { key: 'openBanking', label: '오픈뱅킹 출금 이체 동의' },
+    { key: 'electronFinance', label: '전자금융거래 이용 약관 동의' },
+    { key: 'personalInfo', label: '개인정보 제3자 제공 동의' },
+    { key: 'bankTransfer', label: '은행 출금이체 약관 동의' },
+    { key: 'identification', label: '본인 확인 및 인증 동의' },
+  ];
+
+  const agreementValidations = [
+    { key: 'openBanking', message: '오픈뱅킹 출금 이체에 동의해주세요.' },
+    { key: 'electronFinance', message: '전자금융거래 이용 약관에 동의해주세요.' },
+    { key: 'personalInfo', message: '개인정보 제3자 제공에 동의해주세요.' },
+    { key: 'bankTransfer', message: '은행 출금이체 약관에 동의해주세요.' },
+    { key: 'identification', message: '본인 확인 및 인증에 동의해주세요.' },
+  ];
+
+  const handleNext = () => {
+    const uncheckedItem = agreementValidations.find(
+      (item) => !agreements[item.key as keyof typeof agreements]
+    );
+
+    if (uncheckedItem) {
+      alert(uncheckedItem.message);
+      return;
+    }
+
+    navigate('/register');
+  };
 
   return (
     <div>
@@ -37,95 +93,17 @@ const RegisterAgreement = () => {
       </div>
 
       <div>
-        <div className={styles.agreementItem}>
-          <div className={styles.agreementItemOption}>(필수)</div>
-          <div className={styles.agreementItemTitle}>오픈뱅킹 출금 이체 동의</div>
-          <button
-            className={!check1 ? styles.agreementItemUnCheck : styles.agreementItemCheck}
-            onClick={() => {
-              setCheck1(!check1);
-            }}
-          >
-            ✓
-          </button>
-        </div>
-        <div className={styles.agreementItem}>
-          <div className={styles.agreementItemOption}>(필수)</div>
-          <div className={styles.agreementItemTitle}>전자금융거래 이용 약관 동의</div>
-          <button
-            className={!check2 ? styles.agreementItemUnCheck : styles.agreementItemCheck}
-            onClick={() => {
-              setCheck2(!check2);
-            }}
-          >
-            ✓
-          </button>
-        </div>
-        <div className={styles.agreementItem}>
-          <div className={styles.agreementItemOption}>(필수)</div>
-          <div className={styles.agreementItemTitle}>개인정보 제3자 제공 동의</div>
-          <button
-            className={!check3 ? styles.agreementItemUnCheck : styles.agreementItemCheck}
-            onClick={() => {
-              setCheck3(!check3);
-            }}
-          >
-            ✓
-          </button>
-        </div>
-        <div className={styles.agreementItem}>
-          <div className={styles.agreementItemOption}>(필수)</div>
-          <div className={styles.agreementItemTitle}>은행 출금이체 약관</div>
-          <button
-            className={!check4 ? styles.agreementItemUnCheck : styles.agreementItemCheck}
-            onClick={() => {
-              setCheck4(!check4);
-            }}
-          >
-            ✓
-          </button>
-        </div>
-        <div className={styles.agreementItem}>
-          <div className={styles.agreementItemOption}>(필수)</div>
-          <div className={styles.agreementItemTitle}>본인 확인 및 인증 동의</div>
-          <button
-            className={!check5 ? styles.agreementItemUnCheck : styles.agreementItemCheck}
-            onClick={() => {
-              setCheck5(!check5);
-            }}
-          >
-            ✓
-          </button>
-        </div>
+        {agreementItems.map((item) => (
+          <AgreementItem
+            key={item.key}
+            label={item.label}
+            isChecked={agreements[item.key as keyof typeof agreements]}
+            onToggle={() => updateAgreement(item.key as keyof typeof agreements)}
+          />
+        ))}
       </div>
 
-      <button
-        className={styles.button}
-        onClick={() => {
-          if (!check1) {
-            alert('오픈뱅킹 출금 이체에 동의해주세요.');
-            return;
-          }
-          if (!check2) {
-            alert('전자금융거래 이용 약관에 동의해주세요.');
-            return;
-          }
-          if (!check3) {
-            alert('개인정보 제3자 제공에 동의해주세요.');
-            return;
-          }
-          if (!check4) {
-            alert('은행 출금 이체에 동의해주세요.');
-            return;
-          }
-          if (!check5) {
-            alert('본인 확인 및 인증에 동의해주세요.');
-            return;
-          }
-
-          navigate('/register');
-        }}
-      >
+      <button className={styles.button} onClick={handleNext}>
         다음
       </button>
     </div>

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -82,7 +82,7 @@ const Register = () => {
   return (
     <div>
       <header className={styles.header}>
-        <button className={styles.backButton} onClick={() => navigate('/register/agreement')}>
+        <button className={styles.backButton} onClick={() => navigate(-1)}>
           <BackIcon />
         </button>
         <div className={styles.headerName}>카드 등록하기</div>
@@ -158,7 +158,7 @@ const Register = () => {
             const updatedForm = { ...form, paymentPassword: value };
             card.register(updatedForm);
             alert('카드 정보가 등록되었습니다.');
-            navigate(-1);
+            navigate('/');
           }}
         />
       )}

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -82,7 +82,7 @@ const Register = () => {
   return (
     <div>
       <header className={styles.header}>
-        <button className={styles.backButton} onClick={() => navigate('/')}>
+        <button className={styles.backButton} onClick={() => navigate('/register/agreement')}>
           <BackIcon />
         </button>
         <div className={styles.headerName}>카드 등록하기</div>

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -158,7 +158,7 @@ const Register = () => {
             const updatedForm = { ...form, paymentPassword: value };
             card.register(updatedForm);
             alert('카드 정보가 등록되었습니다.');
-            navigate('/');
+            navigate(-1);
           }}
         />
       )}

--- a/src/router/RouterProvider.tsx
+++ b/src/router/RouterProvider.tsx
@@ -7,11 +7,11 @@ import Main from '@/pages/Main';
 import QrScan from '@/pages/QrScan';
 import UsageHistory from '@/pages/UsageHistory';
 import Filter from '@/pages/UsageHistory/Filter';
-import Payment from '@/pages/Payment';
 import EnterPassword from '@/pages/Payment/EnterPassword';
 import Success from '@/pages/Payment/Success';
 import Fail from '@/pages/Payment/Fail/Index';
 import My from '@/pages/My';
+import RegisterAgreement from '@/pages/Register/RegisterAgreement';
 
 const CustomRouterProvider = () => {
   const browserRouter = createBrowserRouter([
@@ -29,6 +29,10 @@ const CustomRouterProvider = () => {
           element: <Register />,
         },
         {
+          path: 'register/agreement',
+          element: <RegisterAgreement />,
+        },
+        {
           path: 'qr',
           element: <QrScan />,
         },
@@ -39,10 +43,6 @@ const CustomRouterProvider = () => {
         {
           path: 'history/filter',
           element: <Filter />,
-        },
-        {
-          path: 'payment',
-          element: <Payment />,
         },
         {
           path: 'payment/password',

--- a/src/styles/Register.css.ts
+++ b/src/styles/Register.css.ts
@@ -160,3 +160,47 @@ export const gridItem = style({
   textAlign: 'center',
   backgroundColor: '#f9f9f9',
 });
+
+export const agreementTitle = style({
+  fontSize: '1.5rem',
+  fontWeight: 'bold',
+  margin: '1rem',
+});
+
+export const agreementDescription = style({ color: 'gray', margin: '1rem' });
+
+export const agreementItem = style({
+  display: 'flex',
+});
+
+export const agreementItemOption = style({
+  color: 'blue',
+  fontWeight: 'bold',
+  marginTop: '1rem',
+  marginLeft: '1rem',
+});
+
+export const agreementItemTitle = style({
+  marginTop: '1rem',
+  marginLeft: '0.5rem',
+});
+
+export const agreementItemUnCheck = style({
+  color: 'gray',
+  marginTop: '1rem',
+  marginRight: '1rem',
+  position: 'fixed',
+  right: '0',
+  background: 'transparent',
+  border: 'none',
+});
+
+export const agreementItemCheck = style({
+  fontWeight: 'bold',
+  marginTop: '1rem',
+  marginRight: '1rem',
+  position: 'fixed',
+  right: '0',
+  background: 'transparent',
+  border: 'none',
+});

--- a/src/styles/Register.css.ts
+++ b/src/styles/Register.css.ts
@@ -171,6 +171,8 @@ export const agreementDescription = style({ color: 'gray', margin: '1rem' });
 
 export const agreementItem = style({
   display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
 });
 
 export const agreementItemOption = style({
@@ -188,9 +190,7 @@ export const agreementItemTitle = style({
 export const agreementItemUnCheck = style({
   color: 'gray',
   marginTop: '1rem',
-  marginRight: '1rem',
-  position: 'fixed',
-  right: '0',
+  marginLeft: 'auto',
   background: 'transparent',
   border: 'none',
 });
@@ -198,8 +198,7 @@ export const agreementItemUnCheck = style({
 export const agreementItemCheck = style({
   fontWeight: 'bold',
   marginTop: '1rem',
-  marginRight: '1rem',
-  position: 'fixed',
+  marginLeft: 'auto',
   right: '0',
   background: 'transparent',
   border: 'none',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 카드 등록 시 필수 약관 동의 화면이 추가되었습니다. 사용자는 5개의 필수 약관에 모두 동의해야 다음 단계로 진행할 수 있습니다.
- **버그 수정**
	- 카드 추가 버튼 클릭 시 약관 동의 페이지로 이동하도록 경로가 변경되었습니다.
	- 카드 등록 화면의 뒤로가기 버튼이 홈이 아닌 이전 페이지로 이동하도록 수정되었습니다.
- **스타일**
	- 약관 동의 관련 UI 요소에 대한 새로운 스타일이 추가되었습니다.
- **기타**
	- 결제 관련 페이지가 라우터에서 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->